### PR TITLE
Compile fixes & description improvements

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -224,9 +224,9 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_RECALL,
     SPELL_ANIMATE_DEAD,
     SPELL_BORGNJORS_VILE_CLUTCH,
+    SPELL_CIGOTUVIS_PLAGUE,
     SPELL_DEATH_CHANNEL,
     SPELL_SIMULACRUM,
-    SPELL_CIGOTUVIS_PLAGUE,
 },
 
 #if TAG_MAJOR_VERSION == 34
@@ -263,9 +263,9 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Wizardry
     SPELL_FORCE_LANCE,
     SPELL_AGONY,
-    SPELL_HASTE,
     SPELL_INVISIBILITY,
     SPELL_SPELLFORGED_SERVITOR,
+    SPELL_HASTE,
 },
 #endif
 

--- a/crawl-ref/source/dat/species/added_08_two-headed-ogre.yaml
+++ b/crawl-ref/source/dat/species/added_08_two-headed-ogre.yaml
@@ -48,10 +48,11 @@ mutations:
     MUT_TOUGH_SKIN: 2
     MUT_SCREAM: 3
 fake_mutations:
-  - long: You can wield two weapons. but, you can't wear a shield
+  - long: You can wield two weapons at the same time.
     short: dual wield
-  - long: You can wield two amulets
-    short: two head
+  - long: You cannot use shields.
+  - long: You can wear two amulets.
+    short: two heads
 recommended_jobs:
   - JOB_HUNTER
   - JOB_BERSERKER

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1185,6 +1185,11 @@ static string _describe_weapon(const item_def &item, bool verbose)
                                " unaware enemies.";
             }
             break;
+        case SK_MACES_FLAILS:
+            description += "\n\nAttacks with this weapon have a chance to "
+                           "knock back the defender, dealing extra damage if "
+                           "they collide with something.";
+            break;
         default:
             break;
         }

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -236,7 +236,7 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu, int
             && coinflip()) {
             if (defender && defender->alive() && _in_melee_range(defender))
             {
-                mprf("double attack!");
+                mprf("Double attack!");
                 fight_melee(&you, defender, nullptr, simu, attack_num?0:1);
             }
         }

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -2290,8 +2290,7 @@ void makeitem_tests()
         if (item.brand == SPWPN_ORC_SLAYING
             || item.brand == SPWPN_REACHING
             || item.brand == SPWPN_RETURNING
-            || item.brand == SPWPN_CONFUSE
-            || item.brand == SPWPN_DRAGON_SLAYING)
+            || item.brand == SPWPN_CONFUSE)
         {
             item.brand = SPWPN_FORBID_BRAND;
         }

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -784,7 +784,7 @@ void melee_attack::mace_flail_knockback()
 
     if (you.can_see(*defender))
     {
-        mprf("%s %s knocked back by the %s.",
+        mprf("%s %s knocked back by %s.",
             defender->name(DESC_THE).c_str(),
             defender->conj_verb("are").c_str(),
             attacker->name(DESC_THE).c_str());

--- a/crawl-ref/source/webserver/game_data/static/enums.js
+++ b/crawl-ref/source/webserver/game_data/static/enums.js
@@ -54,6 +54,7 @@ define(function () {
     exports.equip = {};
     val = 0;
     exports.equip.WEAPON = val++;
+    exports.equip.SECOND_WEAPON = val++;
     exports.equip.CLOAK = val++;
     exports.equip.HELMET = val++;
     exports.equip.GLOVES = val++;
@@ -63,6 +64,7 @@ define(function () {
     exports.equip.LEFT_RING = val++;
     exports.equip.RIGHT_RING = val++;
     exports.equip.AMULET = val++;
+    exports.equip.AMULET_RIGHT = val++;
     exports.equip.RING_ONE = val++;
     exports.equip.RING_TWO = val++;
     exports.equip.RING_THREE = val++;

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -191,10 +191,10 @@ function ($, comm, enums, map_knowledge, messages, options) {
         return elem;
     }
 
-    function wielded_weapon()
+    function _wielded_weapon(slot)
     {
         var elem;
-        var wielded = player.equip[enums.equip.WEAPON];
+        var wielded = player.equip[slot];
         if (wielded == -1)
         {
             elem = $("<span>");
@@ -208,6 +208,16 @@ function ($, comm, enums, map_knowledge, messages, options) {
             elem.addClass("corroded_weapon");
 
         return elem;
+    }
+
+    function wielded_weapon()
+    {
+        return _wielded_weapon(enums.equip.WEAPON);
+    }
+
+    function wielded_second_weapon()
+    {
+        return _wielded_weapon(enums.equip.SECOND_WEAPON);
     }
 
     function quiver()
@@ -479,6 +489,12 @@ function ($, comm, enums, map_knowledge, messages, options) {
         $("#stats_weapon_letter").text(
             index_to_letter(player.equip[enums.equip.WEAPON]) + ")");
         $("#stats_weapon").html(wielded_weapon());
+        if (player.species == "Two Headed Ogre")
+        {
+            $("#stats_second_weapon_letter").text(
+                index_to_letter(player.equip[enums.equip.SECOND_WEAPON]) + ")");
+            $("#stats_second_weapon").html(wielded_second_weapon());
+        }
         $("#stats_quiver_letter").text(
             index_to_letter(player.quiver_item) + ")");
         $("#stats_quiver").html(quiver());

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -110,6 +110,8 @@
         </div>
         <div style="float:left;width:100%;"><span class="stats_caption" id="stats_weapon_letter"></span>
           <span id="stats_weapon" /></div>
+        <div style="float:left;width:100%;"><span class="stats_caption" id="stats_second_weapon_letter"></span>
+          <span id="stats_second_weapon" /></div>
         <div id="stats_quiver_line" style="float:left;width:100%;"><span class="stats_caption" id="stats_quiver_letter"></span>
           <span id="stats_quiver" /></div>
         <div id="stats_status_lights" style="float:left;width:100%;" />


### PR DESCRIPTION
Fixes:
* Fix `FULLDEBUG=1` compilation (reference to deleted brand `SPWPN_DRAGON_SLAYING`)
* Fix startup (spell book order incorrect)

Features:
* Display Two Headed Ogre second weapon in webtiles
* Improve mutation descriptions for Two Headed Ogre
* Add knockback description to Maces & Flails item view
* Improve wording of knockback messaging