### PR TITLE
장검의 반격 확률을 33%로 되돌림

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -356,7 +356,7 @@ bool melee_attack::handle_phase_dodged()
                 const bool using_fencers = player_equip_unrand(UNRAND_FENCERS);
                 const int chance = using_lbl + using_fencers;
 
-                if (x_chance_in_y(chance, 2) && !is_riposte) // no ping-pong!
+                if (x_chance_in_y(chance, 3) && !is_riposte) // no ping-pong!
                     riposte(i == 0);
 
                 // Retaliations can kill!


### PR DESCRIPTION
50%로 상향된 성능이 너무 강하다는 의견이 많았기에
장검의 반격 확률을 33%로 다시 되돌립니다