### PR TITLE
Update added_05_lesser-lich.yaml

### DIFF
--- a/crawl-ref/source/dat/species/added_05_lesser-lich.yaml
+++ b/crawl-ref/source/dat/species/added_05_lesser-lich.yaml
@@ -41,7 +41,7 @@ aptitudes:
 str: 7
 int: 12
 dex: 4
-levelup_stat_frequency: 4
+levelup_stat_frequency: 5
 levelup_stats:
   - int
 mutations:


### PR DESCRIPTION
영구적인 리치가 되면 와일드매직+명석함을 얻어서 왕귀종족으로 아이덴티티가 설정된 레서리치의 스탯증가 단위레벨을 4에서 5로 수정함.