### PR TITLE
change collector's starting item(balance)

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -2015,7 +2015,7 @@ static void _make_artefact_acquirement_items(vector<object_class_type>& rand_cla
 {
 
     const int wanted_randart_num = min(2, (int)rand_classes.size());
-    const int wanted_unrandart_num = 5;
+    const int wanted_unrandart_num = 9;
     shuffle_array(rand_classes);
 
     CrawlVector& acq_items = you.props[ACQUIRE_ITEMS_KEY].get_vector();

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1067,7 +1067,7 @@ gear that hasn't been seen yet, but, alas, nothing is guaranteed.
 %%%%
 scroll of collection
 
-A two-of-a-kind scroll which summon to the special artefact from 
+A one-of-a-kind scroll which summon to the special artefact from 
 Collector's artefact collections, with the reader choosing the artefact to be summoned.
 %%%%
 scroll of amnesia

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -328,9 +328,9 @@ static const map<job_type, job_def> job_data =
     "Cl", "Collector",
     5, 3, 4,
     { SP_HILL_ORC, SP_MINOTAUR, SP_DEMIGOD, SP_OCTOPODE, SP_TROLL, SP_FELID, SP_HUMAN },
-    { "scroll of collection q:2" }, 
+    { "scroll of collection q:1" }, 
     WCHOICE_NONE,
-    { { SK_FIGHTING, 1 } }, 
+    { { SK_FIGHTING, 3 } }, 
 } },
 #if TAG_MAJOR_VERSION == 34
 { JOB_DEATH_KNIGHT, {


### PR DESCRIPTION
시작 시 scroll of collection을 하나만 가지도록 and 스타팅 스킬을 파이팅 1 -> 3 으로.
scroll of collection을 읽었을 시 나오는 unrandart의 수를 5 -> 9로 증가

초반 너무 루즈해지는현상을 막고 무기가 아닌 다른 아이템을 집었을 시 플레이의 안정성 증가를 위한 밸런스 패치.

나중에 투표할때 의견 모아봐서 이전이 좋은지 새버전이 좋은지 결정해야할듯