### PR TITLE
New_miniVault for jaw

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6417,6 +6417,55 @@ ENDMAP
 #          the second time), OOD monsters that can be easily
 #          escaped, and not using overpowered/useless unrandarts.
 ################################################################
+# The Jaws of Erysichthon
+#
+NAME:  ukdong_guarded_unrand_jaws
+DEPTH: Depths, Crypt:1-2
+: if you.in_branch("Depths") then
+TILE: c = wall_stone_dark
+: else
+TILE: c = wall_crypt
+: end
+WEIGHT: 5
+FTILE: dSV456.? = floor_crypt
+TAGS:  no_monster_gen no_item_gen transparent
+: if you.in_branch("Depths") then
+MONS:  necrophage / place:Depths:$ skeleton, ghoul, flayed ghost, curse skull, revenant, bone dragon
+SUBST: ? = 1:20 2:20 3 .:5
+: else
+MONS:  necrophage / place:Vaults:$ skeleton, ghoul, flayed ghost, curse skull, revenant, bone dragon
+SUBST: ? = 1:20 2:20 3 .:5
+: end
+KPROP: dSV456.? = no_tele_into
+KPROP: Sc = bloody
+ITEM:  The_Jaws_of_Erysichthon  no_pickup
+{{
+  dgn.delayed_decay(_G, 'Z', "human skeleton / orc skeleton / elf skeleton"
+                             .. " / dwarf skeleton / elf corpse w:5"
+                             .. " / human corpse w:5 / dwarf corpse w:5"
+                             .. " / merfolk skeleton w:1")
+}}
+SUBST: S = Z:15 .
+MAP
+...............
+.cccncccccnccc.
+.c?c?c?c?c?c?c
+.ccSSSSSSSSScc.
+.c?SVSSSSSVS?c.
+.ccSScc=ccSScc.
+.c?SSc.6.cSS?c.
+.ccSVc4d4cVScc.
+.c?SSc.5.cSS?c.
+.ccSSccnccSScc.
+.c?SVSSVSSVS?c.
+.ccSSSSSSSSScc.
+.c?c?cS.Sc?c?c.
+.cccncc+ccnccc.
+...............
+ENDMAP
+
+
+
 # Robustness
 #
 NAME:   minmay_guarded_unrand_robustness


### PR DESCRIPTION
![캡처](https://user-images.githubusercontent.com/65288602/91209365-93b41100-e746-11ea-81ea-4f428e5c17ba.PNG)

![캡처2](https://user-images.githubusercontent.com/65288602/91209369-957dd480-e746-11ea-9e31-a336e758006e.PNG)


해당 미니볼트는 에리쉬톤의 턱을 위한 지형입니다.

출현하는 브랜치는 크립트 1,2층과 뎁스 전층입니다.

가을 카타나, 저주의 낫 등의 미니 볼트보다는 나타날 확률이 높으며
무지의 방패, 저항의 방패(등딱지)와 같은 미니 볼트보다는 낮습니다.


2년 간 돌죽을 1500판 정도 하면서 가을 카타나 지형은 단 한 번도 본 적이 없고, 저주의 낫은 두번정도 본 것을 생각했을때
이것보단 확률이 커도 되겠다고 생각했습니다.
한 판에 0.05% 확률로 생성되는 건가? 아니면 그 이하인 걸로 생각하고 있습니다. 확률 관련해선 제대로 이해를 못해서..


외곽에 있는 곳에는 네크로파지 혹은 해당 층에 어울리는 스켈레톤이 나올 확률이 약 1/3 정도, 구울이 나올 확률 1/3 정도, 플레이드 고스트 혹은 아무것도 나타나지 않을 확률이 나머지 1/3 정도 되지만, 아무것도 나오지 않을 확률은 10프로 이하로 적은 편입니다. 나중에 시간이 나면 각 몹이 나올 최솟값을 정하는 걸 추가하고 싶습니다만, 자살이 마려워지기 시작했기 때문에 그냥 다이스의 신에게  일단은 맡기기로 했습니다.

중앙에는 커스스컬 2마리와, 본드래곤 1마리, 레버넌트 1마리가 고정적으로 출현합니다. 레버넌트는 다소 테마와 어울리지 않을 수 있지만, 결국 망령과 비슷하게 생기기도 했고 결정적으로 언데드 플레이어에게도 위협적인 몹이 필요했기 때문에 포함시켰습니다.

