### PR TITLE
Improve desc of unrand

### DIFF
--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -18,7 +18,9 @@ Wrath of Trog
 
 A bloodstained axe that was the favourite weapon of the old god Trog, before it
 was lost. It induces a bloodthirsty berserker rage in warriors who use it in
-battle.
+battle. It bears the wrath against the magic and its existence itself disrupts 
+the spells and the magical abilities around the wielder.
+
 %%%%
 mace of Variability
 
@@ -712,11 +714,12 @@ true within, but not without.
 %%%%
 The Jaws of Erysichthon
 
-The owner of this jaw was cursed by a terrible hunger when he was alive. He is 
-already dead, but his jaws still remain, and make strangely and threateningly 
-crackling sound as it seems to soothe unfilled hunger. Since it makes wielder
-suffer a terrible hunger, wielder sucks a bloods and devours every livings to
-fill its hunger.
+A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
+aroused the divine wrath and the king was cursed and fell into the endless hunger.
+Eventually he ended up eating himself and died, but his jaw still remains. It
+still makes strange and threatening sounds as it crackles to fill its bottomless
+hunger. The wearer of it will suffer a terrible hunger and devour their foes
+alive to soothe their hunger.
 %%%%
 scales of the Unseen Dragon
 


### PR DESCRIPTION
Add the antimagic aura desc of 트찐따's wrath
Improve the desc of the jaw

그런데, 턱 이름에 the가 붙어 있는게 조금 걸립니다. 아이템중에 관사가 붙은 경우는 아예 없는 것 같습니다.
이거랑 같이 수정하려고 하는데, 혹시 jaw를 복수형으로 쓴 거에 어떤 의도가 있나요? 그런 게 아니면 s 다 뺴버리게요.
물론 타일 이미지 관련한 부분은 건드리지 않고요
