### PR TITLE
Improve desc of unrands and jaw

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1401,7 +1401,7 @@ INSCRIP:  rRot
 BOOL:     drain, evil, special, no_upgrade
 
 ENUM:     JAWS
-NAME:     Erysichthon's Jaw
+NAME:     The Jaws of Erysichthon
 OBJ:      OBJ_ARMOUR/ARM_HAT
 PLUS:     +0
 COLOUR:   ETC_UNHOLY

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1401,7 +1401,7 @@ INSCRIP:  rRot
 BOOL:     drain, evil, special, no_upgrade
 
 ENUM:     JAWS
-NAME:     The Jaws of Erysichthon
+NAME:     Erysichthon's Jaw
 OBJ:      OBJ_ARMOUR/ARM_HAT
 PLUS:     +0
 COLOUR:   ETC_UNHOLY

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6417,7 +6417,7 @@ ENDMAP
 #          the second time), OOD monsters that can be easily
 #          escaped, and not using overpowered/useless unrandarts.
 ################################################################
-# The Jaws of Erysichthon
+# Erysichthon's Jaw
 #
 NAME:  ukdong_guarded_unrand_jaws
 DEPTH: Depths, Crypt:1-2
@@ -6438,7 +6438,7 @@ SUBST: ? = 1:20 2:20 3 .:5
 : end
 KPROP: dSV456.? = no_tele_into
 KPROP: Sc = bloody
-ITEM:  The_Jaws_of_Erysichthon  no_pickup
+ITEM:  Erysichthon's_Jaw  no_pickup
 {{
   dgn.delayed_decay(_G, 'Z', "human skeleton / orc skeleton / elf skeleton"
                              .. " / dwarf skeleton / elf corpse w:5"

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6417,7 +6417,7 @@ ENDMAP
 #          the second time), OOD monsters that can be easily
 #          escaped, and not using overpowered/useless unrandarts.
 ################################################################
-# Erysichthon's Jaw
+# The Jaws of Erysichthon
 #
 NAME:  ukdong_guarded_unrand_jaws
 DEPTH: Depths, Crypt:1-2
@@ -6438,7 +6438,7 @@ SUBST: ? = 1:20 2:20 3 .:5
 : end
 KPROP: dSV456.? = no_tele_into
 KPROP: Sc = bloody
-ITEM:  Erysichthon's_Jaw  no_pickup
+ITEM:  The_Jaws_of_Erysichthon  no_pickup
 {{
   dgn.delayed_decay(_G, 'Z', "human skeleton / orc skeleton / elf skeleton"
                              .. " / dwarf skeleton / elf corpse w:5"

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -18,9 +18,7 @@ Wrath of Trog
 
 A bloodstained axe that was the favourite weapon of the old god Trog, before it
 was lost. It induces a bloodthirsty berserker rage in warriors who use it in
-battle. It bears the wrath against the magic and its existence itself disrupts 
-the spells and the magical abilities around the wielder.
-
+battle.
 %%%%
 mace of Variability
 
@@ -714,12 +712,11 @@ true within, but not without.
 %%%%
 The Jaws of Erysichthon
 
-A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
-aroused the divine wrath and the king was cursed and fell into the endless hunger.
-Eventually he ended up eating himself and died, but his jaw still remains. It
-still makes strange and threatening sounds as it crackles to fill its bottomless
-hunger. The wearer of it will suffer a terrible hunger and devour their foes
-alive to soothe their hunger.
+The owner of this jaw was cursed by a terrible hunger when he was alive. He is 
+already dead, but his jaws still remain, and make strangely and threateningly 
+crackling sound as it seems to soothe unfilled hunger. Since it makes wielder
+suffer a terrible hunger, wielder sucks a bloods and devours every livings to
+fill its hunger.
 %%%%
 scales of the Unseen Dragon
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -714,7 +714,7 @@ true within, but not without.
 Erysichthon's Jaw
 
 A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
-aroused the divine wrath and the king was ccursed with the endless hunger.
+aroused the divine wrath and the king was accursed with the endless hunger.
 Eventually he ended up eating himself and died, but his jaw still remains. It
 still makes strange crackling sounds even though it has no upper jaw to crackle.
 The wearer of it will suffer a terrible hunger and devour their foes alive to 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -18,7 +18,9 @@ Wrath of Trog
 
 A bloodstained axe that was the favourite weapon of the old god Trog, before it
 was lost. It induces a bloodthirsty berserker rage in warriors who use it in
-battle.
+battle. It bears the wrath against the magic and its existence itself disrupts 
+the spells and the magical abilities around the wielder.
+
 %%%%
 mace of Variability
 
@@ -712,11 +714,12 @@ true within, but not without.
 %%%%
 The Jaws of Erysichthon
 
-The owner of this jaw was cursed by a terrible hunger when he was alive. He is 
-already dead, but his jaws still remain, and make strangely and threateningly 
-crackling sound as it seems to soothe unfilled hunger. Since it makes wielder
-suffer a terrible hunger, wielder sucks a bloods and devours every livings to
-fill its hunger.
+A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
+aroused the divine wrath and the king was cursed and fell into the endless hunger.
+Eventually he ended up eating himself and died, but his jaw still remains. It
+still makes strange and threatening sounds as it crackles to fill its bottomless
+hunger. The wearer of it will suffer a terrible hunger and devour their foes
+alive to soothe their hunger.
 %%%%
 scales of the Unseen Dragon
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -18,8 +18,7 @@ Wrath of Trog
 
 A bloodstained axe that was the favourite weapon of the old god Trog, before it
 was lost. It induces a bloodthirsty berserker rage in warriors who use it in
-battle. It bears the wrath against the magic and its existence itself disrupts 
-the spells and the magical abilities around the wielder.
+battle.
 %%%%
 mace of Variability
 
@@ -711,14 +710,13 @@ recently dead, sucking them in, protecting the wearer with a cocoon of carrion.
 This protection only lasts a short time, however - the ward against decay holds
 true within, but not without.
 %%%%
-Erysichthon's Jaw
+The Jaws of Erysichthon
 
-A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
-aroused the divine wrath and the king was ccursed with the endless hunger.
-Eventually he ended up eating himself and died, but his jaw still remains. It
-still makes strange crackling sounds even though it has no upper jaw to crackle.
-The wearer of it will suffer a terrible hunger and devour their foes alive to 
-soothe their bottomless hunger.
+The owner of this jaw was cursed by a terrible hunger when he was alive. He is 
+already dead, but his jaws still remain, and make strangely and threateningly 
+crackling sound as it seems to soothe unfilled hunger. Since it makes wielder
+suffer a terrible hunger, wielder sucks a bloods and devours every livings to
+fill its hunger.
 %%%%
 scales of the Unseen Dragon
 
@@ -731,29 +729,20 @@ damaged, but also corrodes into contamination.
 %%%%
 Golem gauntlets
 
-A pair of gauntlets made of the crystal from unknown source. This cumbersome,
-heavy armour protects the wearer from poison and electricity. 
-It has an indescribable power within, but these gloves alone cannot unleash
-the potential of the armour.
+A pair of gauntlets made like fists of golem. It's enough to protect your hands,
+but it's not suitable for hiding because of its size.
 %%%%
 Golem greaves
 
-A pair of greaves made of the crystal from unknown source. This cumbersome,
-heavy armour protects the wearer from poison and electricity. 
-It has an indescribable power within, but these greaves alone cannot unleash
-the potential of the armour.
+A pair of gauntlets made like legs of golem. It's enough to protect your foots,
+but it's not suitable for hiding because of its size.
 %%%%
 Golem helmet
 
-A heavy helmet made of the crystal from unknown source. This cumbersome,
-heavy armour protects the wearer from poison and electricity. 
-It has an indescribable power within, but this helmet alone cannot unleash
-the potential of the armour.
+A heavy helmet made like a head of golem. It's enough to protect your head,
+but it's not suitable for hiding because of its size.
 %%%%
 Golem armour
 
-A suit of armour made of the crystal from unknown source. This cumbersome,
-heavy armour protects the wearer from poison and electricity. 
-It has an indescribable power within, but this armour alone cannot unleash
-the potential of the armour. It can be re-assembled to activate as a giant 
-golem exoskeleton, if the wearer has other all parts of this armour.
+A suit of armour made like a bodyparts of golem. It can be re-assembled to
+activate as a giant golem exoskeleton; If you find other parts of this armuor.

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -18,7 +18,8 @@ Wrath of Trog
 
 A bloodstained axe that was the favourite weapon of the old god Trog, before it
 was lost. It induces a bloodthirsty berserker rage in warriors who use it in
-battle.
+battle. It bears the wrath against the magic and its existence itself disrupts 
+the spells and the magical abilities around the wielder.
 %%%%
 mace of Variability
 
@@ -710,13 +711,14 @@ recently dead, sucking them in, protecting the wearer with a cocoon of carrion.
 This protection only lasts a short time, however - the ward against decay holds
 true within, but not without.
 %%%%
-The Jaws of Erysichthon
+Erysichthon's Jaw
 
-The owner of this jaw was cursed by a terrible hunger when he was alive. He is 
-already dead, but his jaws still remain, and make strangely and threateningly 
-crackling sound as it seems to soothe unfilled hunger. Since it makes wielder
-suffer a terrible hunger, wielder sucks a bloods and devours every livings to
-fill its hunger.
+A lower jaw of a human that was once a king of the mighty kingdom. His arrogance
+aroused the divine wrath and the king was ccursed with the endless hunger.
+Eventually he ended up eating himself and died, but his jaw still remains. It
+still makes strange crackling sounds even though it has no upper jaw to crackle.
+The wearer of it will suffer a terrible hunger and devour their foes alive to 
+soothe their bottomless hunger.
 %%%%
 scales of the Unseen Dragon
 
@@ -729,20 +731,29 @@ damaged, but also corrodes into contamination.
 %%%%
 Golem gauntlets
 
-A pair of gauntlets made like fists of golem. It's enough to protect your hands,
-but it's not suitable for hiding because of its size.
+A pair of gauntlets made of the crystal from unknown source. This cumbersome,
+heavy armour protects the wearer from poison and electricity. 
+It has an indescribable power within, but these gloves alone cannot unleash
+the potential of the armour.
 %%%%
 Golem greaves
 
-A pair of gauntlets made like legs of golem. It's enough to protect your foots,
-but it's not suitable for hiding because of its size.
+A pair of greaves made of the crystal from unknown source. This cumbersome,
+heavy armour protects the wearer from poison and electricity. 
+It has an indescribable power within, but these greaves alone cannot unleash
+the potential of the armour.
 %%%%
 Golem helmet
 
-A heavy helmet made like a head of golem. It's enough to protect your head,
-but it's not suitable for hiding because of its size.
+A heavy helmet made of the crystal from unknown source. This cumbersome,
+heavy armour protects the wearer from poison and electricity. 
+It has an indescribable power within, but this helmet alone cannot unleash
+the potential of the armour.
 %%%%
 Golem armour
 
-A suit of armour made like a bodyparts of golem. It can be re-assembled to
-activate as a giant golem exoskeleton; If you find other parts of this armuor.
+A suit of armour made of the crystal from unknown source. This cumbersome,
+heavy armour protects the wearer from poison and electricity. 
+It has an indescribable power within, but this armour alone cannot unleash
+the potential of the armour. It can be re-assembled to activate as a giant 
+golem exoskeleton, if the wearer has other all parts of this armour.


### PR DESCRIPTION
The jaws of Erysichthon -> Erysichthon's Jaw

아랫턱만 남아있다는 설정을 desc에 추가
이름은 jaw로 수정했으나  타일 이미지 등 부분의 unrand_jaws 명은 바꾸지 않았음. 어차피 코드 관련이기 때문에

골렘 아머들의 설명의 오타 및 형식 수정.

트로그의 분노 도끼 설명에 안티매직 오라에 관한 설명 추가


커밋 중간에 본 김치죽의 커밋을 끌어오느라 상당히 개판이지만 바꾼 것은 별로 없습니다.
