### PR TITLE
Pakellas_experimentation, Allow undead golem abil

### DIFF
--- a/crawl-ref/source/dat/des/altar/pakellas_experiments.des
+++ b/crawl-ref/source/dat/des/altar/pakellas_experiments.des
@@ -253,7 +253,6 @@ NAME:    gammafunk_pakellas_cloud_experiment
 TAGS:    temple_overflow_1 temple_overflow_pakellas uniq_altar_pakellas
 TAGS:    generate_awake no_monster_gen no_trap_gen no_item_gen no_pool_fixup
 DEPTH:   D:2-
-WEIGHT:  0
 KFEAT:   _ = altar_pakellas
 MONS:    hungry ghost / ugly thing / hydra / rakshasa spells:none ; nothing \
          / fire dragon / wolf spider / ice dragon
@@ -285,7 +284,6 @@ NAME:    gammafunk_pakellas_statue_experiment
 TAGS:    temple_overflow_1 temple_overflow_pakellas uniq_altar_pakellas
 TAGS:    generate_awake no_item_gen no_monster_gen no_trap_gen no_pool_fixup
 DEPTH:   D:2-
-WEIGHT:  0
 KFEAT:   g = iron_grate
 KFEAT:   _ = altar_pakellas
 : if you.depth() <= 7 then
@@ -320,7 +318,6 @@ NAME:   gammafunk_pakellas_spire_experiment
 TAGS:   temple_overflow_1 temple_overflow_pakellas uniq_altar_pakellas
 TAGS:   generate_awake no_monster_gen no_item_gen no_trap_gen no_pool_fixup
 DEPTH:  D:2-
-WEIGHT: 0
 KFEAT:  g = iron_grate
 KFEAT:  _ = altar_pakellas
 MONS:   gargoyle ; nothing / deep elf knight ; nothing / manticore / cyclops \
@@ -355,7 +352,6 @@ NAME:   gammafunk_pakellas_its_alive
 TAGS:   temple_overflow_1 temple_overflow_pakellas uniq_altar_pakellas
 TAGS:   generate_awake no_monster_gen no_item_gen no_trap_gen no_pool_fixup
 DEPTH:  D:2-
-WEIGHT: 0
 KFEAT:  g = iron_grate
 KFEAT:  h = iron_grate
 KFEAT:  _ = altar_pakellas

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1646,6 +1646,9 @@ undead_form_reason lifeless_prevents_form(transformation which_trans,
     if (which_trans == transformation::shadow)
         return UFR_GOOD; // even the undead can use dith's shadow form
 
+    if (which_trans == transformation::golem)
+        return UFR_GOOD; // even the undead can activates golem armour
+
     if (you.species != SP_VAMPIRE)
         return UFR_TOO_DEAD; // ghouls & mummies can't become anything else
 


### PR DESCRIPTION
파켈라스의 실험은 꽤 신선한 지형이고, 파켈이 부활한 김치죽에 로어를 불어넣어줄 수 있는 좋은 지형입니다. 4개의 미니볼트 중 하나만 나오도록 코드가 짜여있는 듯합니다. 당연히 아예 안나올 수도 있고요.

언데드도 골렘 아머를 사용할 수 있도록 버그를 수정합니다.

ㅋㅋ 오늘 하루 커밋에 다 갖다박았누