### PR TITLE
Rework for angel, part 1

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2780,7 +2780,7 @@ static spret _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_TSO_CLEANSING_FLAME:
     {
-        if (you.species == SP_ANGEL && you.piety >= piety_breakpoint(3))
+        if (you.species == SP_ANGEL)
         {
             targeter_radius hitfunc(&you, LOS_SOLID, 3);
             {

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2329,7 +2329,7 @@ static spret _do_ability(const ability_def& abil, bool fail)
         scaled_delay(1000);
 #endif
         you.wield_change = true;
-        drain_player(600, false, true);
+        drain_player(150, false, true);
         mprf("%s is now bound in your memories.",
             wpn->name(DESC_YOUR).c_str());
         break;
@@ -4332,6 +4332,12 @@ static void _pay_ability_costs(const ability_def& abil)
 
     if (piety_cost)
         lose_piety(piety_cost);
+
+    if (abil.ability == ABIL_ELYVILON_HEAL_OTHER
+        && you.species == SP_ANGEL)
+    {
+        you.props["angel_heal_other"] = piety_cost;
+    }
 }
 
 // for The Great Wyrm

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2780,14 +2780,25 @@ static spret _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_TSO_CLEANSING_FLAME:
     {
-        targeter_radius hitfunc(&you, LOS_SOLID, 2);
+        if (you.species == SP_ANGEL && you.piety >= piety_breakpoint(3))
         {
-            if (stop_attack_prompt(hitfunc, "harm", _cleansing_flame_affects))
-                return spret::abort;
+            targeter_radius hitfunc(&you, LOS_SOLID, 3);
+            {
+                if (stop_attack_prompt(hitfunc, "harm", _cleansing_flame_affects))
+                    return spret::abort;
+            }
+        }
+        else
+        {
+            targeter_radius hitfunc(&you, LOS_SOLID, 2);
+            {
+                if (stop_attack_prompt(hitfunc, "harm", _cleansing_flame_affects))
+                    return spret::abort;
+            }
         }
         fail_check();
         cleansing_flame(10 + you.skill_rdiv(SK_INVOCATIONS, 7, 6),
-                        cleansing_flame_source::invocation, you.pos(), &you);
+                            cleansing_flame_source::invocation, you.pos(), &you);
         break;
     }
 

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -289,7 +289,11 @@ Cleansing Flame ability
 Invokes a huge blast of divine fury centered on the user, severely damaging
 undead and demons and dealing damage to all other hostile creatures. The user's
 allies are never affected. The power of the blast is increased by Invocations
-skill.
+skill.{{
+    if you.race() == "Angel" then
+        return " Also, as an angel of ths Shining One, your blast of holy flame gets wider. "
+    end
+}}
 %%%%
 Summon Divine Warrior ability
 
@@ -495,7 +499,11 @@ pacified while it is asleep.
 Whether the pacification succeeds or not, the invested food, piety and magic
 points are lost. If it does succeed, the monster is healed and you gain half
 the monster's experience value. Otherwise, the monster is unaffected and you
-gain nothing.
+gain nothing.{{
+    if you.race() == "Angel" then
+        return " Also, as an angel of Elyvilon, natural or holy beings will follow you. If you heals already pacified beings, you will restore piety cost to used this. If you can use purification, this ability can be used to purify your allies. "
+    end
+}}
 %%%%
 Greater Healing ability
 

--- a/crawl-ref/source/mon-data.h
+++ b/crawl-ref/source/mon-data.h
@@ -1245,7 +1245,7 @@ static monsterentry mondata[] =
     2, 9, MST_NO_SPELLS, CE_NOCORPSE, S_SQUEAL,
     I_ANIMAL, HT_LAND, 14, DEFAULT_ENERGY,
     MONUSE_NOTHING, SIZE_SMALL, MON_SHAPE_QUADRUPED,
-    {TILEP_MONS_HOLY_SWINE,}, TILE_ERROR
+    {TILEP_MONS_HOLY_SWINE}, TILE_ERROR
 },
 
 { // a dummy monster for recolouring

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1028,12 +1028,22 @@ static bool _ely_protect_ally(monster* mons, killer_type killer)
     if (!MON_KILL(killer) && !YOU_KILL(killer))
         return false;
 
-    if ( mons->holiness() & ~(MH_HOLY | MH_NATURAL)
-        || !mons->friendly()
-        || !you.can_see(*mons) // for simplicity
-        || !one_chance_in(20))
-    {
-        return false;
+    if (you.species == SP_ANGEL) {
+        if ( mons->holiness() & ~(MH_HOLY | MH_NATURAL)
+            || !mons->friendly()
+            || !you.can_see(*mons)
+            || !one_chance_in(20 - min(16, you.piety/10)))
+        {
+            return false; // for angels: 5%~25% chance to protect
+        }
+    } else {
+        if ( mons->holiness() & ~(MH_HOLY | MH_NATURAL)
+            || !mons->friendly()
+            || !you.can_see(*mons) // for simplicity
+            || !one_chance_in(20))
+        {
+            return false;
+        }
     }
 
     mons->hit_points = 1;

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1100,7 +1100,6 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
         else
             mon->god = GOD_XOM;
     }
-
     // Holy monsters need their halo!
     if (mon->holiness() & MH_HOLY)
         invalidate_agrid(true);
@@ -2888,7 +2887,8 @@ bool player_angers_monster(monster* mon, bool real)
 
     // Get the drawbacks, not the benefits... (to prevent e.g. demon-scumming).
     conduct_type why = player_will_anger_monster(*mon);
-    if (why && (!real || mon->wont_attack()))
+    if (why && (!real || mon->wont_attack())
+        && !(testbits(mon->flags, MF_PACIFIED) && mon-> attitude == ATT_FRIENDLY)) // for angels
     {
         if (real)
         {

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -47,6 +47,7 @@
 #include "mon-behv.h"
 #include "mon-book.h"
 #include "mon-death.h"
+#include "mon-grow.h"
 #include "mon-place.h"
 #include "mon-poly.h"
 #include "mon-tentacle.h"
@@ -3662,6 +3663,39 @@ void mons_pacify(monster& mon, mon_attitude_type att, bool no_xp)
             make_stringf(" discards %s horn.",
                          mon.pronoun(PRONOUN_POSSESSIVE).c_str()).c_str());
         monster_drop_things(&mon, false, item_is_horn_of_geryon);
+    }
+
+    if (you.species == SP_ANGEL)
+    {
+        switch (mon.type)
+        {
+        case MONS_FIRE_DRAGON:
+        case MONS_ICE_DRAGON:
+        case MONS_STEAM_DRAGON:
+        case MONS_SWAMP_DRAGON:
+        case MONS_ACID_DRAGON:
+        case MONS_QUICKSILVER_DRAGON:
+        case MONS_IRON_DRAGON:
+        case MONS_GOLDEN_DRAGON:
+        case MONS_SHADOW_DRAGON:
+        {
+            mprf("%s is become a blessed pearl dragon.",
+                mon.name(DESC_THE, false).c_str());
+            mon.upgrade_type(MONS_PEARL_DRAGON, true, true);
+            break;
+        }
+        
+        case MONS_HOG:
+        {
+            mprf("%s is become a blessed holy swine.",
+                mon.name(DESC_THE, false).c_str());
+            mon.upgrade_type(MONS_HOLY_SWINE, true, true);
+            break;
+        }
+
+        default:
+            break;
+        }
     }
 
     // End constriction.

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1393,6 +1393,8 @@ void setup_cleansing_flame_beam(bolt &beam, int pow,
     {
         beam.thrower   = KILL_YOU;
         beam.source_id = MID_PLAYER;
+        if (you.species == SP_ANGEL && you_worship(GOD_SHINING_ONE))
+            beam.ex_size = 3;
     }
     else
     {


### PR DESCRIPTION
https://github.com/kimjoy2002/crawl/issues/410#issuecomment-6870709

엘리빌론: 타인 치유로 자연적/신성한 존재를 동료로 만들 수 있음. 정화 습득시 타인 치유에 정화 효과가 추가되며, 우호적인 대상에게 타인 치유 사용시 소모된 신앙을 돌려받음.
- 처음에 의도한 것과 다르게 악신을 숭배하는 비-언데드 인간형 몬스터도 교화해서 동료로 만들 수 있음. 해보니까 괜찮아서 그대로 추가함.
- 동료로 만들 때 악마의 무기를 들고 있었다면 축복받은 무기로 바뀜. 단, 고통/수확/흡수/흡혈 브랜드의 경우 브랜드가 없는 상태가 되며, 그외의 경우에도 기존 브랜드를 그대로 이어받음.
- 용 계열 몹과 돼지는 진주 용과 신성한 돼지로 바뀜.

샤이닝 원: 신성한 불꽃의 범위가 2칸에서 3칸으로 증가.