### PR TITLE
변수명 변환 : agraphede_poison_shield to agraphede_poison_entomoplatlet

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -447,7 +447,7 @@ static const vector<god_passive> god_passives[] =
             "You can not gain poison resistance",
             "You can gain poison resistance"
         },
-        { 1, passive_t::agraphede_poison_shield,
+        { 1, passive_t::agraphede_poison_entomoplatelet,
             "converts a certain percentage of damage to poison" },
         { 2, passive_t::agraphede_poison_regen,
             "get regen while poisoned" },

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -284,7 +284,7 @@ enum class passive_t
     /// Poison resistance disappears
     agraphede_anti_poison_resist,
     /// Converts the received damage to a certain percentage poison.
-    agraphede_poison_shield,
+    agraphede_poison_entomoplatelet,
     /// Get Regen while poisoned
     agraphede_poison_regen,
     /// Deprived of poison resistance of enemies in sight

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -856,7 +856,7 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
         dam = max(0, do_shave_damage(dam));
     }
 
-    if (have_passive(passive_t::agraphede_poison_shield)
+    if (have_passive(passive_t::agraphede_poison_entomoplatelet)
         && death_type != KILLED_BY_POISON
         && you_worship(GOD_AGRAPHEDE)
         && dam != INSTANT_DEATH


### PR DESCRIPTION
실제로 SH와는 다르니 shield와 다른 용어를 쓰는게 낫지 않을까 합니다.
독벌레들이 상처에 혈소판처럼 작용한다, 뭐 그런 느낌의 작명입니다. (entomo- + platlet)