### PR TITLE
for Trog + Meliai, allow to invoke smite while berserk

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -359,7 +359,6 @@ static const ability_def Ability_List[] =
     { ABIL_CARAVAN_GIFT_ITEM, "Give Item to Mercenary",
         0, 0, 0, 0, {}, abflag::starve_ok },
 
-
     { ABIL_BURIALIZE, "Burialize Weapon", 0, 0, 0, 0, {},
         abflag::starve_ok | abflag::skill_drain },
 
@@ -1572,6 +1571,10 @@ static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
 {
     if (you.berserk() && !testbits(abil.flags, abflag::berserk_ok))
     {
+        if (you.species == SP_MELIAI && you_worship(GOD_TROG)
+              && abil.ability == ABIL_MELIAI_SMITE)
+            return true;
+
         if (!quiet)
             canned_msg(MSG_TOO_BERSERK);
         return false;

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -103,7 +103,11 @@ Invoke Smite ability
 
 Smites any targeted enemy within sight, with no direct line of fire required.
 The strength of the smiting is increased by Experience level.
-This ability causing drain yourself.
+This ability causing drain yourself. {{
+    if you.god() == "Trog" then
+        return "As a worshipper of Trog, you can invoke smite while berserk."
+    end
+}}
 %%%%
 Exsanguinate ability
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1149,7 +1149,7 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
             return "you can't see any valid targets.";
     }
 
-    if (you_worship(GOD_TROG))
+    if (you_worship(GOD_TROG) && spell != SPELL_SMITING)
     {
         return "you don't and can't cast any spell.";
     }
@@ -1157,6 +1157,12 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
     // Check for banned schools (Currently just Ru sacrifices)
     if (!fake_spell && cannot_use_schools(get_spell_disciplines(spell)))
         return "you cannot use spells of this school.";
+
+    if (you.species == SP_MELIAI)
+    {
+        if (spell == SPELL_LEDAS_LIQUEFACTION)
+           return "you can't cast this while perpetually flying.";
+    }
 
     if (you.species == SP_DJINNI)
     {


### PR DESCRIPTION
- 트로그를 믿으면 스마이트를 쓸 수 없던 버그 수정
- 트로그를 믿을 때 한정으로, 버서크 상태에서도 스마이트를 쓸 수 있도록 변경
  - 김치죽 트로그는 모든 '권능'을 버서크 상태에서도 제공하는데, 스마이트도 권능이기 때문.
  - 이를 통해 원거리 계열 적성이 좋지 않아 트로그의 탄약 하사로 이득을 거의 볼 수 없는 점이 약간 상쇄될 것
    (오카와루의 경우 히로이즘+신앙목 효과로 적성 페널티를 어느 정도 상쇄하는게 가능해서 보완할 필요까진 없음)