### PR TITLE
As the positions of ends of stairs of hell, their heights also vary.

### DIFF
--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -81,8 +81,9 @@ As a god of illusory reality, Imus Thea rules a reflection, refraction, diffract
 and dispersion of presences and his powers cause the ramification of uncountably many
 illusory realms. As a result, his followers will reflect, bend and spray projectiles
 and the enemy's fire, even if magical beams of breath of dragons under his power. 
-they can blind enemies with prismatic prism, and call out their avatar from the 
-illusory beyond. However, they will be fragile as a mirror or lens. 
+His followers also begin to project illusory reality into the space around them through
+their existence. They can blind enemies with prismatic prism, and call out their avatar
+from the illusory beyond. However, they will be fragile as a mirror or lens in return. 
 %%%%
 Wu Jian
 

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -992,6 +992,17 @@ level_id stair_destination(dungeon_feature_type feat, const string &dst,
         ASSERT(!at_branch_bottom());
         level_id lev = level_id::current();
         lev.depth++;
+        if (is_hell_subbranch(lev.branch))
+        {
+            int max_depth = brdepth[lev.branch];
+
+            // stairs of hell drop you 1/2/3 levels with equal chance.
+            // 33.3% for 1, 2, 3 from D:3, less before
+            lev.depth += random2(2);
+
+            if (lev.depth > max_depth)
+                lev.depth = max_depth;
+        }
         return lev;
     }
 


### PR DESCRIPTION
지옥이 너무 길다는 의견이 있었고,

임시 방편으로 다음과 같은 패치를 제안합니다.

"지옥의 계단은 끝도 변하지만 높이도 변한다."

Shaft처럼 1/3의 확률로 1,2,3층을 이동합니다.

일단 본가 크롤의 경우, 마법 실패 패널티가 조정된 탓에 본의 아니게 지옥 난이도가 쉬워졌는데, 김치죽도 나름 이런 요소를 넣어서 완화시켜보면 좋을 듯 합니다.